### PR TITLE
Implement datagram buffering and add diagnostic telemetry

### DIFF
--- a/lib/telemetry_metrics_statsd/counter_error.ex
+++ b/lib/telemetry_metrics_statsd/counter_error.ex
@@ -1,0 +1,33 @@
+defmodule TelemetryMetricsStatsd.CounterError do
+  @counter_ref "telemetry_metrics_statsd_counter_error_ref"
+
+  @spec init :: any()
+  def init do
+    :persistent_term.put(@counter_ref, :counters.new(1, [:write_concurrency]))
+  end
+
+  @spec reset :: :ok
+  def reset do
+    :counters.put(:persistent_term.get(@counter_ref), 1, 0)
+  end
+
+  @spec destroy :: any()
+  def destroy do
+    :persistent_term.erase(@counter_ref)
+  end
+
+  @spec increment(integer()) :: :ok
+  def increment(incr \\ 1) when is_integer(incr) and incr > 0 do
+    :counters.add(:persistent_term.get(@counter_ref), 1, incr)
+  end
+
+  @spec decrement(integer()) :: :ok
+  def decrement(decr \\ 1) when is_integer(decr) and decr > 0 do
+    :counters.sub(:persistent_term.get(@counter_ref), 1, decr)
+  end
+
+  @spec get :: any()
+  def get do
+    :counters.get(:persistent_term.get(@counter_ref), 1)
+  end
+end

--- a/lib/telemetry_metrics_statsd/counter_ok.ex
+++ b/lib/telemetry_metrics_statsd/counter_ok.ex
@@ -1,0 +1,33 @@
+defmodule TelemetryMetricsStatsd.CounterOk do
+  @counter_ref "telemetry_metrics_statsd_counter_ok_ref"
+
+  @spec init :: any()
+  def init do
+    :persistent_term.put(@counter_ref, :counters.new(1, [:write_concurrency]))
+  end
+
+  @spec reset :: :ok
+  def reset do
+    :counters.put(:persistent_term.get(@counter_ref), 1, 0)
+  end
+
+  @spec destroy :: any()
+  def destroy do
+    :persistent_term.erase(@counter_ref)
+  end
+
+  @spec increment(integer()) :: :ok
+  def increment(incr \\ 1) when is_integer(incr) and incr > 0 do
+    :counters.add(:persistent_term.get(@counter_ref), 1, incr)
+  end
+
+  @spec decrement(integer()) :: :ok
+  def decrement(decr \\ 1) when is_integer(decr) and decr > 0 do
+    :counters.sub(:persistent_term.get(@counter_ref), 1, decr)
+  end
+
+  @spec get :: any()
+  def get do
+    :counters.get(:persistent_term.get(@counter_ref), 1)
+  end
+end

--- a/lib/telemetry_metrics_statsd/options.ex
+++ b/lib/telemetry_metrics_statsd/options.ex
@@ -61,10 +61,24 @@ defmodule TelemetryMetricsStatsd.Options do
     ],
     mtu: [
       type: :non_neg_integer,
-      default: 512,
+      # https://github.com/DataDog/datadog-go/blob/3255e6186e83fad1e447573c9fa03dd13c023394/statsd/statsd.go#L35-L41
+      # usually IPv4 networks are configured with a MTU of 1500 bytes, so packet size should <= MTU
+      default: 1432,
       doc:
         "Maximum Transmission Unit of the link between your application and the StastD server in bytes. " <>
           "If this value is greater than the actual MTU of the link, UDP packets with published metrics will be dropped."
+    ],
+    buffer_flush_ms: [
+      type: :non_neg_integer,
+      default: 0,
+      doc:
+        "The maximum time in milliseconds to wait before flushing the buffer. If the buffer is not full, it will be flushed after this time."
+    ],
+    diagnostic_metrics_report_interval: [
+      type: :non_neg_integer,
+      # every 15 seconds
+      default: 15_000,
+      doc: "The interval in milliseconds when diagnostic metrics are published"
     ]
   ]
 

--- a/lib/telemetry_metrics_statsd/udp_worker.ex
+++ b/lib/telemetry_metrics_statsd/udp_worker.ex
@@ -1,0 +1,116 @@
+defmodule TelemetryMetricsStatsd.UDPWorker do
+  @moduledoc false
+
+  use GenServer
+
+  alias TelemetryMetricsStatsd.{UDP, Packet, CounterOk, CounterError}
+
+  @default_buffer_flush_ms 1000
+  @default_max_datagram_size 1432
+
+  defstruct [
+    :reporter,
+    :pool_id,
+    :buffered_datagram,
+    :buffer_flush_ms,
+    :max_datagram_size
+  ]
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @impl true
+  def init(opts) do
+    buffer_flush_ms = opts[:buffer_flush_ms] || @default_buffer_flush_ms
+
+    state = %__MODULE__{
+      reporter: opts[:reporter],
+      pool_id: opts[:pool_id],
+      buffered_datagram: [],
+      buffer_flush_ms: buffer_flush_ms,
+      max_datagram_size: opts[:max_datagram_size] || @default_max_datagram_size
+    }
+
+    schedule_flush(state)
+
+    {:ok, state}
+  end
+
+  def publish_datagrams(pid, datagrams) do
+    GenServer.call(pid, {:publish_datagrams, datagrams})
+  end
+
+  @impl true
+  def handle_call({:publish_datagrams, datagrams}, _from, state) do
+    new_buffered_datagrams =
+      Enum.reduce(datagrams, state.buffered_datagram, &do_append_datagram/2)
+
+    cond do
+      state.buffer_flush_ms == 0 ->
+        for packet <- Packet.build_packets(datagrams, state.max_datagram_size, "\n") do
+          maybe_send_udp_datagrams(state, packet)
+        end
+
+        {:reply, :ok, %{state | buffered_datagram: []}}
+
+      Enum.any?(datagrams, fn datagram -> IO.iodata_length(datagram) > state.max_datagram_size end) ->
+        {:reply,
+         {:error, "Payload is too big (more than #{state.max_datagram_size} bytes), dropped."},
+         state}
+
+      IO.iodata_length(new_buffered_datagrams) > state.max_datagram_size ->
+        maybe_send_udp_datagrams(state)
+
+        {:reply, :ok, %{state | buffered_datagram: datagrams}}
+
+      true ->
+        {:reply, :ok, %{state | buffered_datagram: new_buffered_datagrams}}
+    end
+  end
+
+  defp maybe_send_udp_datagrams(state, datagrams \\ nil) do
+    datagrams_to_send = datagrams || state.buffered_datagram
+
+    if datagrams_to_send != [] do
+      case TelemetryMetricsStatsd.get_udp(state.pool_id) do
+        {:ok, udp} ->
+          case UDP.send(udp, datagrams_to_send) do
+            :ok ->
+              CounterOk.increment()
+
+              :ok
+
+            {:error, reason} ->
+              CounterError.increment()
+
+              TelemetryMetricsStatsd.udp_error(state.reporter, udp, reason)
+          end
+
+        :error ->
+          :ok
+      end
+    else
+      :ok
+    end
+  end
+
+  @impl true
+  def handle_info(:buffer_flush, state) do
+    if state.buffered_datagram != [] do
+      maybe_send_udp_datagrams(state)
+    end
+
+    schedule_flush(state)
+
+    {:noreply, %{state | buffered_datagram: []}}
+  end
+
+  defp schedule_flush(%{buffer_flush_ms: buffer_flush_ms}) when buffer_flush_ms > 0,
+    do: Process.send_after(self(), :buffer_flush, buffer_flush_ms)
+
+  defp schedule_flush(_), do: :ok
+
+  defp do_append_datagram([], first_datagram), do: first_datagram
+  defp do_append_datagram(current_buffer, datagram), do: [current_buffer, "\n", datagram]
+end

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -1,6 +1,8 @@
 defmodule TelemetryMetricsStatsd.Test.Helpers do
   @moduledoc false
 
+  use ExUnit.Case
+
   def given_counter(event_name, opts \\ []) do
     Telemetry.Metrics.counter(event_name, opts)
   end
@@ -19,5 +21,25 @@ defmodule TelemetryMetricsStatsd.Test.Helpers do
 
   def given_distribution(event_name, opts \\ []) do
     Telemetry.Metrics.distribution(event_name, opts)
+  end
+
+  def setup_telemetry(events, config \\ []) do
+    telemetry_handle_id = "test-telemetry-handler-#{inspect(self())}"
+
+    :ok =
+      :telemetry.attach_many(
+        telemetry_handle_id,
+        events,
+        &send_to_pid/4,
+        config
+      )
+
+    :ok = on_exit(fn -> :telemetry.detach(telemetry_handle_id) end)
+  end
+
+  defp send_to_pid(event, measurements, metadata, config) do
+    pid = config[:pid] || self()
+
+    send(pid, {:telemetry_event, {event, measurements, metadata, config}})
   end
 end


### PR DESCRIPTION
Original implementation is missing the buffering functionality, so added in this PR with a minimal diagnostic metrics.

Default MTU size adjusted to match with the one used by official DataDog clients.